### PR TITLE
Clean serviceRegistry subgraph after update in contract

### DIFF
--- a/src/mappings/service-registry.ts
+++ b/src/mappings/service-registry.ts
@@ -51,27 +51,6 @@ export function handleServiceDataCreated(event: ServiceDataCreated): void {
   service.save()
 }
 
-export function handleServiceConfirmed(event: ServiceConfirmed): void {
-  const service = getOrCreateService(event.params.id)
-  service.status = 'Confirmed'
-  service.updatedAt = event.block.timestamp
-  service.save()
-}
-
-export function handleServiceFinished(event: ServiceFinished): void {
-  const service = getOrCreateService(event.params.id)
-  service.status = 'Finished'
-  service.updatedAt = event.block.timestamp
-  service.save()
-}
-
-export function handleServiceRejected(event: ServiceRejected): void {
-  const service = getOrCreateService(event.params.id)
-  service.status = 'Rejected'
-  service.updatedAt = event.block.timestamp
-  service.save()
-}
-
 export function handleServiceDetailedUpdated(event: ServiceDetailedUpdated): void {
   const service = getOrCreateService(event.params.id)
   service.uri = event.params.newServiceDataUri

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -7,7 +7,7 @@ dataSources:
     network: fuji
     source:
       abi: TalentLayerID
-      address: "0x9a76eA2C056B6Bee5A1179BBece77D28FceE48C4"
+      address: '0x9a76eA2C056B6Bee5A1179BBece77D28FceE48C4'
       startBlock: 16571490
     mapping:
       kind: ethereum/events
@@ -44,7 +44,7 @@ dataSources:
     network: fuji
     source:
       abi: TalentLayerReview
-      address: "0xD8c4fD1D8Dd2f3a6E4d26BeB167e73D9E28db7F0"
+      address: '0xD8c4fD1D8Dd2f3a6E4d26BeB167e73D9E28db7F0'
       startBlock: 16571490
     mapping:
       kind: ethereum/events
@@ -71,7 +71,7 @@ dataSources:
     network: fuji
     source:
       abi: ServiceRegistry
-      address: "0x9EA2678d5A69CEDEc52ecafA367659b1d2Ff7824"
+      address: '0x9EA2678d5A69CEDEc52ecafA367659b1d2Ff7824'
       startBlock: 16571490
     mapping:
       kind: ethereum/events
@@ -90,14 +90,6 @@ dataSources:
           handler: handleServiceCreated
         - event: ServiceDataCreated(uint256,string)
           handler: handleServiceDataCreated
-        - event: ServiceSellerAssigned(uint256,uint256,uint8)
-          handler: handleServiceSellerAssigned
-        - event: ServiceConfirmed(uint256,uint256,uint256,string)
-          handler: handleServiceConfirmed
-        - event: ServiceRejected(uint256,uint256,uint256,string)
-          handler: handleServiceRejected
-        - event: ServiceFinished(uint256,uint256,uint256,string)
-          handler: handleServiceFinished
         - event: ServiceDetailedUpdated(indexed uint256,string)
           handler: handleServiceDetailedUpdated
         - event: ProposalCreated(uint256,uint256,string,uint8,address,uint256)
@@ -114,7 +106,7 @@ dataSources:
     network: fuji
     source:
       abi: TalentLayerMultipleArbitrableTransaction
-      address: "0x8754a129D3F53222dd94Ce45749134c15C9Ed119"
+      address: '0x8754a129D3F53222dd94Ce45749134c15C9Ed119'
       startBlock: 16571490
     mapping:
       kind: ethereum/events
@@ -152,7 +144,7 @@ dataSources:
     network: fuji
     source:
       abi: TalentLayerPlatformID
-      address: "0x8799479a39b6e563969126328e2323cbA01e8742"
+      address: '0x8799479a39b6e563969126328e2323cbA01e8742'
       startBlock: 16571490
     mapping:
       kind: ethereum/events


### PR DESCRIPTION
Delete event in subgraph.yaml :
ServiceSellerAssigned / ServiceConfirmed /  ServiceRejected / ServiceFinished

Delete in mapping :
handleServiceConfirmed / handleServiceFinished / handleServiceRejected

Fully tested with local deployed and display in local GraphQL dashboard ✅
