### PR TITLE
Ipfs search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,7 @@ deploy-goerli:
 	graph codegen
 	graph build --network goerli
 	graph deploy --node https://api.thegraph.com/deploy/ talentlayer/talent-layer-protocol
-c: 
-	graph codegen
-cb:
-	graph codegen
-	graph build --network goerli
-cbd:
+deploy-goerli-test:
 	graph codegen
 	graph build --network goerli
 	graph deploy --product hosted-service empaemanuel/talentlayer-goereli

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,12 @@ deploy-goerli:
 	graph codegen
 	graph build --network goerli
 	graph deploy --node https://api.thegraph.com/deploy/ talentlayer/talent-layer-protocol
+c: 
+	graph codegen
+cb:
+	graph codegen
+	graph build --network goerli
+cbd:
+	graph codegen
+	graph build --network goerli
+	graph deploy --product hosted-service empaemanuel/talentlayer-goereli

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@graphprotocol/graph-cli": "^0.25.1",
-        "@graphprotocol/graph-ts": "^0.26.0"
+        "@graphprotocol/graph-ts": "^0.29.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-ts": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.26.0.tgz",
-      "integrity": "sha512-GW/emOJl+35MXgmIxTnUK7dJtPCaB9u5aAwoLVqJ8swogC794O92UrXMVrAJsherUriu+yI9bLMGmNPOIi60jw==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.29.1.tgz",
+      "integrity": "sha512-GhAP2ijk3cTM0xBjoAFxEmdZbYl1BueCYqAGw5G7UyBX3EV8FWkvD5DMam6IkLGqXasBmelCFrROK3B5t6zVdg==",
       "dependencies": {
         "assemblyscript": "0.19.10"
       }
@@ -4460,9 +4460,9 @@
       }
     },
     "@graphprotocol/graph-ts": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.26.0.tgz",
-      "integrity": "sha512-GW/emOJl+35MXgmIxTnUK7dJtPCaB9u5aAwoLVqJ8swogC794O92UrXMVrAJsherUriu+yI9bLMGmNPOIi60jw==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.29.1.tgz",
+      "integrity": "sha512-GhAP2ijk3cTM0xBjoAFxEmdZbYl1BueCYqAGw5G7UyBX3EV8FWkvD5DMam6IkLGqXasBmelCFrROK3B5t6zVdg==",
       "requires": {
         "assemblyscript": "0.19.10"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.25.1",
-    "@graphprotocol/graph-ts": "^0.26.0"
+    "@graphprotocol/graph-ts": "^0.29.0"
   }
 }

--- a/run-graph-node.sh
+++ b/run-graph-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose down -v;
+docker compose down -v;
 
 if [ -d "data" ]
 then
@@ -9,4 +9,4 @@ then
   sudo rm -rf data/;
 fi
 
-docker-compose up;
+docker compose up;

--- a/schema.graphql
+++ b/schema.graphql
@@ -25,7 +25,7 @@ type Service @entity {
   proposals: [Proposal!] @derivedFrom(field: "service") # proposals for this service
   platform: Platform # Platform on which service was created
   title: String
-  description: Description @derivedFrom(field: "service") # metadata URI of service
+  description: Description @derivedFrom(field: "services") # metadata URI of service
 }
 
 type Description @entity {
@@ -37,7 +37,7 @@ type Description @entity {
   role: String
   rateToken: String
   rateAmount: String
-  service: Service!
+  services: [Service!]
 }
 
 type Review @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -24,7 +24,25 @@ type Service @entity {
   transactionId: String # Escrow transaction id of service
   proposals: [Proposal!] @derivedFrom(field: "service") # proposals for this service
   platform: Platform # Platform on which service was created
+  title: String
+  description: Description @derivedFrom(field: "service") # metadata URI of service
 }
+
+type Description @entity {
+  id: ID! #cid
+  title: String
+  about: String
+  keywords: [String!]
+  keywords_raw: String
+  role: String
+  rateToken: String
+  rateAmount: String
+  service: Service!
+}
+
+# type Keyword @entity {
+#   id: ID! #keyword
+# }
 
 type Review @entity {
   id: ID! # review nft id

--- a/schema.graphql
+++ b/schema.graphql
@@ -32,17 +32,13 @@ type Description @entity {
   id: ID! #cid
   title: String
   about: String
-  keywords: [String!]
-  keywords_raw: String
+  keywords: [String!] #transformed version of keywords
+  keywords_raw: String #stores keywords in their raw format
   role: String
   rateToken: String
   rateAmount: String
   service: Service!
 }
-
-# type Keyword @entity {
-#   id: ID! #keyword
-# }
 
 type Review @entity {
   id: ID! # review nft id

--- a/src/mappings/metadata-registry.ts
+++ b/src/mappings/metadata-registry.ts
@@ -1,16 +1,17 @@
 import { log, ipfs, json, Bytes, dataSource } from '@graphprotocol/graph-ts'
 import { Service, Description } from '../../generated/schema'
 
+//Adds metadata from ipfs as a entity called Description.
+//The description entity has the id of the cid to the file on IPFS
+//Keywords are transformed so that they are only single worded and comma seperated.
+//Keywords are currently stored in two versions, in their raw format as keywords_raw and in a transformed format called keywords.
 export function handleMetadata(content: Bytes): void {
   let context = dataSource.context();
-  let serviceId = context.getString("serviceId"); // this returns correct numbers
-
+  let serviceId = context.getString("serviceId");
   let description = new Description(dataSource.stringParam())
-
   const value = json.fromBytes(content).toObject();
 
   if(value){
-    log.info("========= VALUE IS TRUE", [])
     const title = value.get('title');
     const about = value.get('about');
     let keywords = value.get('keywords');
@@ -18,23 +19,42 @@ export function handleMetadata(content: Bytes): void {
     const rateToken = value.get('rateToken');
     const rateAmount = value.get('rateAmount');
 
-    if(title && about && keywords && role && rateToken && rateAmount){
-      description.title = title.toString();
-      description.about = about.toString();
-      description.role = role.toString();
-      description.rateToken = rateToken.toString();
-      description.rateAmount = rateAmount.toString();
+    if(serviceId){
       description.service = serviceId
+    } else {
+      log.error("Requsted a serviceId, but none was given.{}", [])
+      return
+    }
+    
+    if(title){
+      description.title = title.toString();
+    } 
 
+    if(about){
+      description.about = about.toString();
+    } 
+
+    if(role){
+      description.role = role.toString();
+    }
+
+    if(rateToken){
+      description.rateToken = rateToken.toString();
+    }
+
+    if(rateAmount){
+      description.rateAmount = rateAmount.toString();
+    }
+
+    if(keywords){
+      //Transforms keywords into lowercase, semicolumn seperated keywords in an array.
       var _keywords = keywords.toString().toLowerCase();
       description.keywords_raw = _keywords;
       _keywords = _keywords.replaceAll(", ", ",");
       _keywords = _keywords.replaceAll(" ", ",");
-      description.keywords = _keywords.split(",");
+      description.keywords = _keywords.split(","); 
     }
-    description.save();
 
-  } else {
-    log.info("========= VALUE IS FALSE", [])
+    description.save();
   }
-  
+}

--- a/src/mappings/metadata-registry.ts
+++ b/src/mappings/metadata-registry.ts
@@ -1,0 +1,40 @@
+import { log, ipfs, json, Bytes, dataSource } from '@graphprotocol/graph-ts'
+import { Service, Description } from '../../generated/schema'
+
+export function handleMetadata(content: Bytes): void {
+  let context = dataSource.context();
+  let serviceId = context.getString("serviceId"); // this returns correct numbers
+
+  let description = new Description(dataSource.stringParam())
+
+  const value = json.fromBytes(content).toObject();
+
+  if(value){
+    log.info("========= VALUE IS TRUE", [])
+    const title = value.get('title');
+    const about = value.get('about');
+    let keywords = value.get('keywords');
+    const role = value.get('role');
+    const rateToken = value.get('rateToken');
+    const rateAmount = value.get('rateAmount');
+
+    if(title && about && keywords && role && rateToken && rateAmount){
+      description.title = title.toString();
+      description.about = about.toString();
+      description.role = role.toString();
+      description.rateToken = rateToken.toString();
+      description.rateAmount = rateAmount.toString();
+      description.service = serviceId
+
+      var _keywords = keywords.toString().toLowerCase();
+      description.keywords_raw = _keywords;
+      _keywords = _keywords.replaceAll(", ", ",");
+      _keywords = _keywords.replaceAll(" ", ",");
+      description.keywords = _keywords.split(",");
+    }
+    description.save();
+
+  } else {
+    log.info("========= VALUE IS FALSE", [])
+  }
+  

--- a/src/mappings/metadata-registry.ts
+++ b/src/mappings/metadata-registry.ts
@@ -20,7 +20,13 @@ export function handleMetadata(content: Bytes): void {
     const rateAmount = value.get('rateAmount');
 
     if(serviceId){
-      description.service = serviceId
+      var services = description.services
+      if(services){
+        services.push(serviceId)
+      } else {
+        services = [serviceId]
+      }
+      description.services = services
     } else {
       log.error("Requsted a serviceId, but none was given.{}", [])
       return

--- a/src/mappings/service-registry.ts
+++ b/src/mappings/service-registry.ts
@@ -42,24 +42,15 @@ export function handleServiceCreated(event: ServiceCreated): void {
   service.save()
 }
 
-// ============================ START OF IPFS SEARCH WIP ================================================
-
 export function handleServiceDataCreated(event: ServiceDataCreated): void {
-  const service = getOrCreateService(event.params.id)
-
-  let cid = event.params.serviceDataUri
-  service.uri = cid
-  service.save()
-
-  let context = new DataSourceContext();
-
-  context.setString("serviceId", event.params.id.toString())
+  const serviceId = event.params.id.toString()
+  const cid = event.params.serviceDataUri.toString()
+  
+  const context = new DataSourceContext();
+  context.setString("serviceId", serviceId)
 
   MetadataRegistry.createWithContext(cid, context)
-  // ServiceMetadataTemplate.create(cid)
 }
-
-//===================================== END OF IPFS SEARCH WIP ===========================================
 
 export function handleServiceDetailedUpdated(event: ServiceDetailedUpdated): void {
   const service = getOrCreateService(event.params.id)

--- a/src/mappings/service-registry.ts
+++ b/src/mappings/service-registry.ts
@@ -1,5 +1,6 @@
-import { log } from '@graphprotocol/graph-ts'
+import { log, DataSourceContext } from '@graphprotocol/graph-ts'
 import { Service, User, Token } from '../../generated/schema'
+import { MetadataRegistry } from '../../generated/templates'
 import {
   ServiceCreated,
   ServiceDetailedUpdated,
@@ -40,13 +41,25 @@ export function handleServiceCreated(event: ServiceCreated): void {
 
   service.save()
 }
+
+// ============================ START OF IPFS SEARCH WIP ================================================
+
 export function handleServiceDataCreated(event: ServiceDataCreated): void {
   const service = getOrCreateService(event.params.id)
 
-  service.uri = event.params.serviceDataUri
-
+  let cid = event.params.serviceDataUri
+  service.uri = cid
   service.save()
+
+  let context = new DataSourceContext();
+
+  context.setString("serviceId", event.params.id.toString())
+
+  MetadataRegistry.createWithContext(cid, context)
+  // ServiceMetadataTemplate.create(cid)
 }
+
+//===================================== END OF IPFS SEARCH WIP ===========================================
 
 export function handleServiceDetailedUpdated(event: ServiceDetailedUpdated): void {
   const service = getOrCreateService(event.params.id)

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,14 +1,16 @@
 specVersion: 0.0.4
 schema:
   file: ./schema.graphql
+features:
+  - ipfsOnEthereumContracts
 dataSources:
   - kind: ethereum/contract
     name: TalentLayerID
-    network: fuji
+    network: goerli
     source:
       abi: TalentLayerID
-      address: '0x9a76eA2C056B6Bee5A1179BBece77D28FceE48C4'
-      startBlock: 16571490
+      address: "0x67c3AC531084aB5E6E04d4bB0FC7766e27b81546"
+      startBlock: 8090615
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -41,11 +43,11 @@ dataSources:
       file: ./src/mappings/talent-layer-id.ts
   - kind: ethereum/contract
     name: TalentLayerReview
-    network: fuji
+    network: goerli
     source:
       abi: TalentLayerReview
-      address: '0xD8c4fD1D8Dd2f3a6E4d26BeB167e73D9E28db7F0'
-      startBlock: 16571490
+      address: "0x59ff1f3ff159c17C48558cCf8269FF17aA0B8C8D"
+      startBlock: 8090615
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -68,11 +70,11 @@ dataSources:
       file: ./src/mappings/talent-layer-review.ts
   - kind: ethereum/contract
     name: ServiceRegistry
-    network: fuji
+    network: goerli
     source:
       abi: ServiceRegistry
-      address: '0x9EA2678d5A69CEDEc52ecafA367659b1d2Ff7824'
-      startBlock: 16571490
+      address: "0x6f97FB242d2D3bCA9d19c05c975F6Ec8caB4d1a4"
+      startBlock: 8090615
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -103,11 +105,11 @@ dataSources:
       file: ./src/mappings/service-registry.ts
   - kind: ethereum/contract
     name: TalentLayerEscrow
-    network: fuji
+    network: goerli
     source:
       abi: TalentLayerEscrow
-      address: '0x8754a129D3F53222dd94Ce45749134c15C9Ed119'
-      startBlock: 16571490
+      startBlock: 8090615
+      address: "0x4A6F0208a0b636E3A4918cb0A5B1367E4B338aD8"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -138,14 +140,14 @@ dataSources:
           handler: handlePlatformFeeReleased
         - event: ProtocolFeeUpdated(uint16)
           handler: handleProtocolFeeUpdated
-      file: ./src/mappings/TalentLayerEscrow.ts
+      file: ./src/mappings/talentLayerEscrow.ts
   - kind: ethereum/contract
     name: TalentLayerPlatformID
-    network: fuji
+    network: goerli
     source:
       abi: TalentLayerPlatformID
-      address: '0x8799479a39b6e563969126328e2323cbA01e8742'
-      startBlock: 16571490
+      address: "0x29AcBBbfAb5e1AF98557C53CCcEF0C050FA18Bc8"
+      startBlock: 8090615
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -172,3 +174,18 @@ dataSources:
         - event: MintFeeUpdated(uint256)
           handler: handleMintFeeUpdated
       file: ./src/mappings/talent-layer-platform-id.ts
+templates:
+  - name: MetadataRegistry
+    kind: file/ipfs
+    mapping:
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/mappings/metadata-registry.ts
+      handler: handleMetadata
+      entities:
+        - Description
+        - Service
+      abis:
+        - name: ServiceRegistry
+          file: ./abis/ServiceRegistry.json
+    network: goerli

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,8 +1,6 @@
 specVersion: 0.0.4
 schema:
   file: ./schema.graphql
-features:
-  - ipfsOnEthereumContracts
 dataSources:
   - kind: ethereum/contract
     name: TalentLayerID


### PR DESCRIPTION
Makes it possible to query services using data on IPFS.
When a service is created by the service registry contract a ServiceDataCreated event is emitted. This event is read by the subgraph, which uses the cid that is passed in the event to query data from IPFS. 

It is currently looking for title, role, about, keywords, rateToken, and rateAmount. 
None of the data fields are mandatory and they are null checked individually.

All fields are stored as an entity called Description. The description entity is linked to a Service through the service ID that is passed in the emitted ServiceDataCreated event. 

The field keywords are stored in two formats. One format called keywords_raw, which stores it in its raw format. The other format is stored in the field keywords as an array of strings, where each index represents a single word lowercase keyword.

The ID of the description is its cid. This means that many services can be linked to a single description.
