### PR TITLE
251 - Mint without platform

### DIFF
--- a/src/mappings/talent-layer-id.ts
+++ b/src/mappings/talent-layer-id.ts
@@ -58,9 +58,10 @@ export function handleMint(event: Mint): void {
   const user = getOrCreateUser(event.params._profileId)
   user.address = event.params._user.toHex()
   user.handle = event.params._handle
-  const platform = getOrCreatePlatform(event.params._platformId)
-  user.platform = platform.id
-
+  if (event.params._platformId.notEqual(BigInt.fromI32(0))) {
+    const platform = getOrCreatePlatform(event.params._platformId)
+    user.platform = platform.id
+  }
   user.save()
 
   const protocol = getOrCreateProtocol()


### PR DESCRIPTION
Supports minting a TalentLater ID without linking the profile to a platform. The `platform` field inside the `User` entity will be `null` in this case.